### PR TITLE
Update exportMenu fuction in OwnerActivity to generate sound well

### DIFF
--- a/app/src/main/java/com/example/listen_my_order/activities/OwnerActivity.java
+++ b/app/src/main/java/com/example/listen_my_order/activities/OwnerActivity.java
@@ -150,22 +150,16 @@ public class OwnerActivity extends AppCompatActivity {
             speakOn = false;
         }else{
             // To generate acoustic data
-            euTxManager.euInitTransmit(storeName.getText().toString());
-
+            String message = "";
+            message += storeName.getText().toString();
             int index = 0;
             for(MenuData menuData : menuList){
-                euTxManager.euInitTransmit("\n");
-                euTxManager.euInitTransmit(Integer.toString(index));
-                euTxManager.euInitTransmit(" ");
-                euTxManager.euInitTransmit(menuData.getName());
-                euTxManager.euInitTransmit(" ");
-                euTxManager.euInitTransmit(menuData.getContent());
-                euTxManager.euInitTransmit(" ");
-                euTxManager.euInitTransmit(Float.toString(menuData.getPrice()));
+                message += "/n" + Integer.toString(index) + " " + menuData.getName() + " " + menuData.getContent() + " " + Float.toString(menuData.getPrice());
                 index++;
             }
-            
-//            euTxManager.process(-1);
+            euTxManager.euInitTransmit(message);
+            euTxManager.process(-1);
+            System.out.println(message);
             btn_export_menu.setText("Exporting\nMenu...");
             speakOn = true;
         }


### PR DESCRIPTION
기존 소리 발생 함수가 각자의 문자들을 for문을 통해 음파로 발생시키는데, 소리가 안나오는 경우가 많고 반복해서 소리를 재생할 수 없는 것 같아 하나의 긴 문자열을 만들어서 한 번에 보내는 방식으로 전송 방식을 변경했습니다.
음식명, 설명, 가격 등 정보들의 구분 방식은 하은님이 바꿔주신 것 처럼 "\n"과 띄워쓰기로 그대로 두었습니다.